### PR TITLE
Support reporting with no tests

### DIFF
--- a/src/helpers/test-helpers.js
+++ b/src/helpers/test-helpers.js
@@ -14,7 +14,7 @@ const getTestScore = (runnerResult) => {
     return status === "pass" ? acc + 1 : acc;
   }, 0);
 
-  return (score / tests.length) * (getMaxScoreForTest(runnerResult) || 0);
+  return ((score / tests.length) * getMaxScoreForTest(runnerResult)) || 0;
 };
 
 const getTestWeight = (maxScore, allMaxScores) => {


### PR DESCRIPTION
If there are no tests (e.g. https://github.com/classroom-resources/autograding-python-grader in empty repository), reporter should report zero instead of `NaN`.