### PR TITLE
Fix `getTestScore` to correctly return the sum of scores.

### DIFF
--- a/src/helpers/test-helpers.js
+++ b/src/helpers/test-helpers.js
@@ -9,12 +9,13 @@ const totalPercentageReducer = (acc, { score, weight, maxScore }) => {
 };
 
 const getTestScore = (runnerResult) => {
-  const { tests } = runnerResult;
-  const score = runnerResult.tests.reduce((acc, { status }) => {
-    return status === "pass" ? acc + 1 : acc;
-  }, 0);
+  // const { tests } = runnerResult;
+  // const score = runnerResult.tests.reduce((acc, { status }) => {
+  //   return status === "pass" ? acc + 1 : acc;
+  // }, 0);
 
-  return (score / tests.length) * (getMaxScoreForTest(runnerResult) || 0);
+  // return (score / tests.length) * (getMaxScoreForTest(runnerResult) || 0);
+  return runnerResult.tests.reduce((acc, { score }) => acc + score, 0);
 };
 
 const getTestWeight = (maxScore, allMaxScores) => {


### PR DESCRIPTION
This pull request addresses issue #10  by fixing the getTestScore function to ensure it correctly returns the sum of scores. The previous implementation calculated the total based on how many “pass” were in the status, which was quite odd.