### PR TITLE
Create annotations without using update check run API

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -3,7 +3,6 @@ name: Autograding Tests
   - push
   - workflow_dispatch
 permissions:
-  checks: write
   actions: read
   contents: read
 jobs:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ on:
   - push
   - workflow_dispatch
 permissions:
-  checks: write
   actions: read
   contents: read
 jobs:

--- a/src/notify-classroom.js
+++ b/src/notify-classroom.js
@@ -19,9 +19,14 @@ exports.NotifyClassroom = async function NotifyClassroom(runnerResults) {
   if (!maxPoints) return;
 
   const text = `Points ${totalPoints}/${maxPoints}`;
+  const summary = JSON.stringify({ totalPoints, maxPoints })
 
-  // create a notice annotation with the final result
+  // create notice annotations with the final result and summary
   core.notice(text, {
     title: "Autograding complete",
+  })
+
+  core.notice(summary, {
+    title: "Autograding report",
   })
 };

--- a/src/notify-classroom.js
+++ b/src/notify-classroom.js
@@ -1,5 +1,4 @@
 const core = require("@actions/core");
-const github = require("@actions/github");
 
 exports.NotifyClassroom = async function NotifyClassroom(runnerResults) {
   // combine max score and total score from each {runner, results} pair
@@ -19,74 +18,10 @@ exports.NotifyClassroom = async function NotifyClassroom(runnerResults) {
   );
   if (!maxPoints) return;
 
-  // Our action will need to API access the repository so we require a token
-  // This will need to be set in the calling workflow, otherwise we'll exit
-  const token = process.env.GITHUB_TOKEN || core.getInput("token");
-  if (!token || token === "") return;
-
-  // Create the octokit client
-  const octokit = github.getOctokit(token);
-  if (!octokit) return;
-
-  // The environment contains a variable for current repository. The repository
-  // will be formatted as a name with owner (`nwo`); e.g., jeffrafter/example
-  // We'll split this into two separate variables for later use
-  const nwo = process.env.GITHUB_REPOSITORY || "/";
-  const [owner, repo] = nwo.split("/");
-  if (!owner) return;
-  if (!repo) return;
-
-  // We need the workflow run id
-  const runId = parseInt(process.env.GITHUB_RUN_ID || "");
-  if (Number.isNaN(runId)) return;
-
-  // Fetch the workflow run
-  const workflowRunResponse = await octokit.rest.actions.getWorkflowRun({
-    owner,
-    repo,
-    run_id: runId,
-  });
-
-  // Find the check suite run
-  console.log(`Workflow Run Response: ${workflowRunResponse.data.check_suite_url}`);
-  const checkSuiteUrl = workflowRunResponse.data.check_suite_url;
-  const checkSuiteId = parseInt(checkSuiteUrl.match(/[0-9]+$/)[0], 10);
-
-  const checkRunsResponse = await octokit.rest.checks.listForSuite({
-    owner,
-    repo,
-    check_name: "run-autograding-tests",
-    check_suite_id: checkSuiteId,
-  });
-
-  // Filter to find the check run named "Autograding Tests" for the specific workflow run ID
-  const checkRun = checkRunsResponse.data.total_count === 1 && checkRunsResponse.data.check_runs[0];
-
-  if (!checkRun) return;
-
-  // Update the checkrun, we'll assign the title, summary and text even though we expect
-  // the title and summary to be overwritten by GitHub Actions (they are required in this call)
-  // We'll also store the total in an annotation to future-proof
   const text = `Points ${totalPoints}/${maxPoints}`;
-  await octokit.rest.checks.update({
-    owner,
-    repo,
-    check_run_id: checkRun.id,
-    output: {
-      title: "Autograding",
-      summary: text,
-      text: JSON.stringify({ totalPoints, maxPoints }),
-      annotations: [
-        {
-          // Using the `.github` path is what GitHub Actions does
-          path: ".github",
-          start_line: 1,
-          end_line: 1,
-          annotation_level: "notice",
-          message: text,
-          title: "Autograding complete",
-        },
-      ],
-    },
-  });
+
+  // create a notice annotation with the final result
+  core.notice(text, {
+    title: "Autograding complete",
+  })
 };


### PR DESCRIPTION
Motivation is https://github.com/github/c2c-actions/issues/8652

Tracking issue: https://github.com/github/classroom/issues/5317

Currently how the `Autograding complete` annotation is created is overkill. The workflow run ID is used to fetch the check suite ID and then another API call is made to get the check run ID of a job called `run-autograding-tests`. However, from various examples, `run-autograding-tests` is not the check run name but it is the step name. See for example 

https://github.com/classroom-resources/autograding-io-grader?tab=readme-ov-file#usage where `run-tests` is the job/check-run name. So there is confusion between step names and check run names.

The whole logic can be simplified to create an annotation for the current job using the actions/core NPM package that has a helper for annotations. See https://github.com/actions/toolkit/blob/7f5921cdddc31081d4754a42711d71e7890b0d06/packages/core/README.md#annotations

By using the actions core package correctly, we don't need to leverage the checks API to create annotations so we can run the workflow without the`checks: write` permission.