### PR TITLE
Parsing runners now allows whitespace

### DIFF
--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -73,6 +73,48 @@ test('test runs with multiple runners', () => {
   expect(stdout).toContain('✅')
 })
 
+test('test runs with multiple runners with comma and newline', () => {
+  process.env.RESULT1_RESULTS = Buffer.from(
+    '{ "tests": [{ "name": "Test 1", "status": "pass", "message": null }] }',
+  ).toString('base64')
+  process.env.RESULT2_RESULTS = Buffer.from(
+    '{ "tests": [{ "name": "Test 2", "status": "pass", "message": null }] }',
+  ).toString('base64')
+  process.env.INPUT_RUNNERS = 'result1,\nresult2'
+
+  const child = cp.spawnSync(node, [ip], options)
+  const stdout = child.stdout.toString()
+  console.log(stdout)
+  expect(stdout).toContain('✅')
+})
+test('test runs with multiple runners with comma and space', () => {
+  process.env.RESULT1_RESULTS = Buffer.from(
+    '{ "tests": [{ "name": "Test 1", "status": "pass", "message": null }] }',
+  ).toString('base64')
+  process.env.RESULT2_RESULTS = Buffer.from(
+    '{ "tests": [{ "name": "Test 2", "status": "pass", "message": null }] }',
+  ).toString('base64')
+  process.env.INPUT_RUNNERS = ' result1, result2 '
+
+  const child = cp.spawnSync(node, [ip], options)
+  const stdout = child.stdout.toString()
+  console.log(stdout)
+  expect(stdout).toContain('✅')
+})
+test('test runs with multiple runners with random whitespace', () => {
+  process.env.RESULT1_RESULTS = Buffer.from(
+    '{ "tests": [{ "name": "Test 1", "status": "pass", "message": null }] }',
+  ).toString('base64')
+  process.env.RESULT2_RESULTS = Buffer.from(
+    '{ "tests": [{ "name": "Test 2", "status": "pass", "message": null }] }',
+  ).toString('base64')
+  process.env.INPUT_RUNNERS = '\n\tresult1 \nresult2 \n'
+
+  const child = cp.spawnSync(node, [ip], options)
+  const stdout = child.stdout.toString()
+  console.log(stdout)
+  expect(stdout).toContain('✅')
+})
 test('test fails with multiple runners', () => {
   process.env.RESULT1_RESULTS = Buffer.from(
     '{ "tests": [{ "name": "Test 1", "status": "fail", "message": null }] }',

--- a/src/main.js
+++ b/src/main.js
@@ -5,7 +5,8 @@ const { NotifyClassroom } = require("./notify-classroom");
 try {
   const runnerResults = core
     .getInput("runners")
-    .split(",")
+    .split(/[\s,]/)
+    .filter(Boolean)
     .map((runner) => {
       const encodedResults = process.env[`${runner.trim().toUpperCase()}_RESULTS`];
       const json = Buffer.from(encodedResults, "base64").toString("utf-8");


### PR DESCRIPTION
When setting up reporter in YAML, currently the runners have to be on a single line with no white space.  When there are several, it becomes difficult to maintain as gets wider and wider.

YAML supports several block formats that will allow for a multi-line string but none will remove all the whitespace.  The best it will do is convert newlines to white space.

This update will make allow any form of whitespace in addition to the commas to be used to separate the ids.  This will allow things like:

```
runners: >-
   runner1
   runner2
   runnern
```